### PR TITLE
Add orderPaymentId field to Payment. v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.14.0]
+- add orderPaymentId field to Payment
+
 ## [0.13.1]
 - add Lottie animation as a miniapp loader
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,6 @@ android {
     }
 }
 dependencies {
-    implementation('io.boxo.sdk:boxo-android:1.41.1')
+    implementation('io.boxo.sdk:boxo-android:1.42.0')
     implementation('androidx.fragment:fragment:1.8.5')
 }

--- a/android/src/main/java/io/boxo/expo/ExpoBoxoSdkModule.kt
+++ b/android/src/main/java/io/boxo/expo/ExpoBoxoSdkModule.kt
@@ -97,6 +97,7 @@ class ExpoBoxoSdkModule : Module() {
                         "paymentEvent", mapOf(
                             "appId" to miniapp.appId,
                             "transactionToken" to paymentData.transactionToken,
+                            "orderPaymentId" to paymentData.orderPaymentId,
                             "miniappOrderId" to paymentData.miniappOrderId,
                             "amount" to paymentData.amount,
                             "currency" to paymentData.currency,
@@ -230,6 +231,7 @@ class ExpoBoxoSdkModule : Module() {
                     .sendPaymentResult(
                         PaymentData(
                             transactionToken = paymentEvent.transactionToken ?: "",
+                            orderPaymentId = paymentEvent.orderPaymentId ?: "",
                             miniappOrderId = paymentEvent.miniappOrderId ?: "",
                             amount = paymentEvent.amount ?: 0.0,
                             currency = paymentEvent.currency ?: "",

--- a/android/src/main/java/io/boxo/expo/PaymentEventData.kt
+++ b/android/src/main/java/io/boxo/expo/PaymentEventData.kt
@@ -11,6 +11,9 @@ class PaymentEventData : Record {
     val transactionToken: String? = null
 
     @Field
+    val orderPaymentId: String? = null
+
+    @Field
     val miniappOrderId: String? = null
 
     @Field

--- a/ios/ExpoBoxoSdk.podspec
+++ b/ios/ExpoBoxoSdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'BoxoSDK', '1.27.6'
+  s.dependency 'BoxoSDK', '1.28.0'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/ios/ExpoBoxoSdkModule.swift
+++ b/ios/ExpoBoxoSdkModule.swift
@@ -132,6 +132,7 @@ public class ExpoBoxoSdkModule: Module {
         Function("sendPaymentEvent") { (paymentEvent : PaymentEventData) in
             let paymentData = PaymentData()
             paymentData.transactionToken = paymentEvent.transactionToken ?? ""
+            paymentData.orderPaymentId = paymentEvent.orderPaymentId ?? ""
             paymentData.miniappOrderId = paymentEvent.miniappOrderId ?? ""
             paymentData.amount = paymentEvent.amount ?? 0.0
             paymentData.currency = paymentEvent.currency ?? ""
@@ -189,6 +190,7 @@ extension ExpoBoxoSdkModule : MiniappDelegate {
         let dict = [
             "appId" : miniapp.appId,
             "transactionToken" : paymentData.transactionToken,
+            "orderPaymentId" : paymentData.orderPaymentId,
             "miniappOrderId" : paymentData.miniappOrderId,
             "amount" : paymentData.amount,
             "currency" : paymentData.currency,

--- a/ios/ExpoBoxoSdkModule.swift
+++ b/ios/ExpoBoxoSdkModule.swift
@@ -101,7 +101,8 @@ public class ExpoBoxoSdkModule: Module {
             
             miniApp.setConfig(config: miniappConfig)
             DispatchQueue.main.async {
-                miniApp.open(viewController: UIApplication.shared.delegate!.window!!.rootViewController!)
+                guard let rootViewController = self.resolveRootViewController() else { return }
+                miniApp.open(viewController: rootViewController)
             }
         }
         
@@ -182,6 +183,20 @@ public class ExpoBoxoSdkModule: Module {
                 }
             }
         }
+    }
+
+    private func resolveRootViewController() -> UIViewController? {
+        if #available(iOS 13.0, *) {
+            let windows = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .filter { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive }
+                .flatMap { $0.windows }
+            let keyWindow = windows.first { $0.isKeyWindow } ?? windows.first
+            if let rootViewController = keyWindow?.rootViewController {
+                return rootViewController
+            }
+        }
+        return (UIApplication.shared.delegate?.window ?? nil)?.rootViewController
     }
 }
 

--- a/ios/PaymentEventData.swift
+++ b/ios/PaymentEventData.swift
@@ -15,6 +15,9 @@ struct PaymentEventData : Record {
     var transactionToken: String?
     
     @Field
+    var orderPaymentId: String?
+    
+    @Field
     var miniappOrderId: String?
     
     @Field

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appboxo/expo-boxo-sdk",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Expo wrapper over Boxo SDK for IOS and Android.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/ExpoBoxoSdk.types.ts
+++ b/src/ExpoBoxoSdk.types.ts
@@ -5,6 +5,7 @@ export type AuthEventPayload = {
 export type PaymentData = {
   appId: string;
   transactionToken?: string;
+  orderPaymentId?: string;
   miniappOrderId?: string;
   amount?: number;
   currency?: string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds orderPaymentId to Payment events and SDK types so apps can link payments to orders. Updates native Boxo SDKs and improves iOS root view controller handling; release v0.14.0.

- New Features
  - Add orderPaymentId to Payment on Android, iOS, and TypeScript.
  - Included in emitted paymentEvent and sendPaymentEvent payloads.

- Dependencies
  - Android `io.boxo.sdk:boxo-android` -> `1.42.0`.
  - iOS `BoxoSDK` -> `1.28.0`.
  - Package `@appboxo/expo-boxo-sdk` -> `0.14.0`.

<sup>Written for commit eb678492403072cc4cee4ad36b37156f1f90b2fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Appboxo/expo-boxo-sdk/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

